### PR TITLE
Perform regexp escape on individual words before joining them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # Cocoapods::Search Changelog
 
+## Master
+
+* Perform regexp escape on individual query words before joining them  
+  [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
+  [#8](https://github.com/CocoaPods/cocoapods-search/issues/8)
+
+
 ## 0.1.0 (2015-09-03)
+
 * Version number must not collide with old gem called cocoapods-search 0.0.7
+
 
 ## 0.0.1 (2015-09-03)
 

--- a/lib/cocoapods-search/command/search.rb
+++ b/lib/cocoapods-search/command/search.rb
@@ -16,7 +16,7 @@ module Pod
       def self.options
         [
           ['--regex',   'Interpret the `QUERY` as a regular expression'],
-          ['--full',    'Search by name, summary, description and authors'],
+          ['--full',    'Search by name, summary, description, and authors'],
           ['--stats',   'Show additional stats (like GitHub watchers and forks)'],
           ['--ios',     'Restricts the search to Pods supported on iOS'],
           ['--osx',     'Restricts the search to Pods supported on OS X'],

--- a/lib/cocoapods-search/command/search.rb
+++ b/lib/cocoapods-search/command/search.rb
@@ -73,8 +73,9 @@ module Pod
       end
 
       def local_search
-        query_regex = @query.join(' ').strip
-        query_regex = Regexp.escape(query_regex) unless @use_regex
+        query_regex = @query.reduce('') { |result, q|
+          result + ' ' + (@use_regex ? q : Regexp.escape(q))
+        }.strip
 
         sets = SourcesManager.search_by_name(query_regex, @full_text_search)
         if @supported_on_ios

--- a/lib/cocoapods-search/command/search.rb
+++ b/lib/cocoapods-search/command/search.rb
@@ -16,7 +16,7 @@ module Pod
       def self.options
         [
           ['--regex',   'Interpret the `QUERY` as a regular expression'],
-          ['--full',    'Search by name, summary, and description'],
+          ['--full',    'Search by name, summary, description and authors'],
           ['--stats',   'Show additional stats (like GitHub watchers and forks)'],
           ['--ios',     'Restricts the search to Pods supported on iOS'],
           ['--osx',     'Restricts the search to Pods supported on OS X'],
@@ -73,9 +73,9 @@ module Pod
       end
 
       def local_search
-        query_regex = @query.reduce('') { |result, q|
-          result + ' ' + (@use_regex ? q : Regexp.escape(q))
-        }.strip
+        query_regex = @query.reduce([]) { |result, q|
+          result << (@use_regex ? q : Regexp.escape(q))
+        }.join(' ').strip
 
         sets = SourcesManager.search_by_name(query_regex, @full_text_search)
         if @supported_on_ios

--- a/spec/command/search_spec.rb
+++ b/spec/command/search_spec.rb
@@ -32,7 +32,12 @@ module Pod
       end
 
       it 'searches for a pod with name, summary, or description matching the given query ignoring case' do
-        output = run_command('search', 'Engelhart', '--full')
+        output = run_command('search', 'engelhart', '--full')
+        output.should.include? 'JSONKit'
+      end
+
+      it 'searches for a pod with name, summary, or description matching the given multi-word query ignoring case' do
+        output = run_command('search', 'very', 'high', 'performance', '--full')
         output.should.include? 'JSONKit'
       end
 


### PR DESCRIPTION
To complete changes discussed in #8, we need to change Regexp escaping a little.

Specifically, current implementation performs escape after joining all query argument into a string. For example, while running `pod search --full network library` command, a string like `"network\ library"` will be generated (they joined with space character, then whole string is escaped). This cause a problem inside SourcesManager. Because it needs to search for each query word individually and then return an intersection of individual results, it needs to split given query string to get individual words.

Proposed implementation performs regexp escape on individual query arguments first, then joins escaped strings with space character.
