### PR TITLE
Perform full text search as default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ##### Enhancements
 
+* Perform full search as default, add `--simple` option to search only by name.  
+  [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
+  [#13](https://github.com/CocoaPods/cocoapods-search/issues/13)
+
 * Add support for tvOS and any possible future platforms.  
   [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
   [#11](https://github.com/CocoaPods/cocoapods-search/issues/11)

--- a/lib/cocoapods-search/command/search.rb
+++ b/lib/cocoapods-search/command/search.rb
@@ -4,9 +4,8 @@ module Pod
       self.summary = 'Search for pods.'
 
       self.description = <<-DESC
-        Searches for pods, ignoring case, whose name matches `QUERY`. If the
-        `--full` option is specified, this will also search in the summary and
-        description of the pods.
+        Searches for pods, ignoring case, whose name, summary, description, or authors match `QUERY`. If the
+        `--simple` option is specified, this will only search in the names of the pods.
       DESC
 
       self.arguments = [
@@ -16,7 +15,7 @@ module Pod
       def self.options
         options = [
           ['--regex',   'Interpret the `QUERY` as a regular expression'],
-          ['--full',    'Search by name, summary, description, and authors'],
+          ['--simple',    'Search only by name'],
           ['--stats',   'Show additional stats (like GitHub watchers and forks)'],
           ['--web',     'Searches on cocoapods.org'],
         ]
@@ -28,7 +27,7 @@ module Pod
 
       def initialize(argv)
         @use_regex = argv.flag?('regex')
-        @full_text_search = argv.flag?('full')
+        @simple_search = argv.flag?('simple')
         @stats = argv.flag?('stats')
         @web = argv.flag?('web')
         @platform_filters = Platform.all.map do |platform|
@@ -77,7 +76,7 @@ module Pod
           result << (@use_regex ? q : Regexp.escape(q))
         }.join(' ').strip
 
-        sets = SourcesManager.search_by_name(query_regex, @full_text_search)
+        sets = SourcesManager.search_by_name(query_regex, !@simple_search)
 
         @platform_filters.each do |platform|
           sets.reject! { |set| !set.specification.available_platforms.map(&:name).include?(platform) }

--- a/spec/command/search_spec.rb
+++ b/spec/command/search_spec.rb
@@ -17,7 +17,7 @@ module Pod
 
       it 'runs with correct parameters' do
         lambda { run_command('search', 'JSON') }.should.not.raise
-        lambda { run_command('search', 'JSON', '--full') }.should.not.raise
+        lambda { run_command('search', 'JSON', '--simple') }.should.not.raise
       end
 
       it 'complains for wrong parameters' do
@@ -27,17 +27,17 @@ module Pod
       end
 
       it 'searches for a pod with name matching the given query ignoring case' do
-        output = run_command('search', 'json')
+        output = run_command('search', 'json', '--simple')
         output.should.include? 'JSONKit'
       end
 
       it 'searches for a pod with name, summary, or description matching the given query ignoring case' do
-        output = run_command('search', 'engelhart', '--full')
+        output = run_command('search', 'engelhart')
         output.should.include? 'JSONKit'
       end
 
       it 'searches for a pod with name, summary, or description matching the given multi-word query ignoring case' do
-        output = run_command('search', 'very', 'high', 'performance', '--full')
+        output = run_command('search', 'very', 'high', 'performance')
         output.should.include? 'JSONKit'
       end
 
@@ -55,13 +55,13 @@ module Pod
       end
 
       it 'restricts the search to Pods supported on Watch OS' do
-        output = run_command('search', '', '--watchos')
+        output = run_command('search', 'a', '--watchos')
         output.should.include? 'Realm'
         output.should.not.include? 'BananaLib'
       end
 
       it 'restricts the search to Pods supported on tvOS' do
-        output = run_command('search', '', '--tvos')
+        output = run_command('search', 'n', '--tvos')
         output.should.include? 'monkey'
         output.should.not.include? 'BananaLib'
       end


### PR DESCRIPTION
Closes #13.
- Search will perform full text search on name, summary, description, and authors of the pods.
- Adds `--simple` option to search pods only by name.

Changelog done.
