### PR TITLE
Print output in reverse order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ##### Enhancements
 
+* Print output in reverse order.  
+  [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
+
 * Perform full search as default, add `--simple` option to search only by name.  
   [Muhammed Yavuz Nuzumlalı](https://github.com/manuyavuz)
   [#13](https://github.com/CocoaPods/cocoapods-search/issues/13)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/CocoaPods/CocoaPods.git
-  revision: f7578085842f7a8caca5d8ebbbd99f91a6474e45
+  revision: 64bdde9f5a8bb375a28d5a2b79cd668f982532bd
   branch: master
   specs:
     cocoapods (0.39.0)

--- a/lib/cocoapods-search/command/search.rb
+++ b/lib/cocoapods-search/command/search.rb
@@ -82,7 +82,7 @@ module Pod
           sets.reject! { |set| !set.specification.available_platforms.map(&:name).include?(platform) }
         end
 
-        sets.each do |set|
+        sets.reverse_each do |set|
           begin
             if @stats
               UI.pod(set, :stats)

--- a/spec/command/search_spec.rb
+++ b/spec/command/search_spec.rb
@@ -41,6 +41,11 @@ module Pod
         output.should.include? 'JSONKit'
       end
 
+      it 'prints search results in reverse order' do
+        output = run_command('search', 'lib')
+        output.should.match /JSONKit.*BananaLib/m
+      end
+
       it 'restricts the search to Pods supported on iOS' do
         output = run_command('search', 'BananaLib', '--ios')
         output.should.include? 'BananaLib'


### PR DESCRIPTION
This prints output in reverse order in order to show user most relevant pods first.
