### PR TITLE
Print found pods inside a pager

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: 6f85c4fcff81960c0983616082bc345763a15dc6
+  revision: 6c2544496ed201104e712dd95793ec7bc6a171e8
   branch: master
   specs:
     cocoapods-core (0.39.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/CocoaPods/CocoaPods.git
-  revision: b917ffd9e16769c48a7bf748d8d111e6bd015ac8
+  revision: 6c64eeb69443d9ab18081ad330a134cfb0e46169
   branch: master
   specs:
     cocoapods (0.39.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/CocoaPods/CocoaPods.git
-  revision: 64bdde9f5a8bb375a28d5a2b79cd668f982532bd
+  revision: b917ffd9e16769c48a7bf748d8d111e6bd015ac8
   branch: master
   specs:
     cocoapods (0.39.0)
@@ -21,7 +21,7 @@ GIT
 
 GIT
   remote: https://github.com/CocoaPods/Core.git
-  revision: ce26e1eb797a6ad1f1d94b0304a50c491bc41237
+  revision: 6f85c4fcff81960c0983616082bc345763a15dc6
   branch: master
   specs:
     cocoapods-core (0.39.0)

--- a/lib/cocoapods-search/command/search.rb
+++ b/lib/cocoapods-search/command/search.rb
@@ -85,8 +85,9 @@ module Pod
         end
 
         if @use_pager
-          IO.popen(('$PAGER' || 'less -R'), 'w') do |io|
-            UI.io_type = io
+          IO.popen((ENV['PAGER'] || 'less -R'), 'w') do |io|
+            Signal.trap('INT','IGNORE')
+            UI.output_io = io
             print_sets(sets)
           end
         else

--- a/lib/cocoapods-search/command/search.rb
+++ b/lib/cocoapods-search/command/search.rb
@@ -84,12 +84,8 @@ module Pod
           sets.reject! { |set| !set.specification.available_platforms.map(&:name).include?(platform) }
         end
 
-        if @use_pager
-          IO.popen((ENV['PAGER'] || 'less -R'), 'w') do |io|
-            Signal.trap('INT','IGNORE')
-            UI.output_io = io
-            print_sets(sets)
-          end
+        if(@use_pager)
+          UI.with_pager { print_sets(sets) }
         else
           print_sets(sets)
         end

--- a/spec/command/search_spec.rb
+++ b/spec/command/search_spec.rb
@@ -8,7 +8,6 @@ module Pod
       @test_source = Source.new(fixture('spec-repos/test_repo'))
       Source::Aggregate.any_instance.stubs(:sources).returns([@test_source])
       SourcesManager.updated_search_index = nil
-      Command::Search.any_instance.stubs(:use_pager).returns(false)
     end
 
     describe 'Search' do

--- a/spec/command/search_spec.rb
+++ b/spec/command/search_spec.rb
@@ -8,6 +8,7 @@ module Pod
       @test_source = Source.new(fixture('spec-repos/test_repo'))
       Source::Aggregate.any_instance.stubs(:sources).returns([@test_source])
       SourcesManager.updated_search_index = nil
+      Command::Search.any_instance.stubs(:use_pager).returns(false)
     end
 
     describe 'Search' do
@@ -41,9 +42,9 @@ module Pod
         output.should.include? 'JSONKit'
       end
 
-      it 'prints search results in reverse order' do
+      it 'prints search results in order' do
         output = run_command('search', 'lib')
-        output.should.match /JSONKit.*BananaLib/m
+        output.should.match /BananaLib.*JSONKit/m
       end
 
       it 'restricts the search to Pods supported on iOS' do

--- a/spec/spec_helper/command.rb
+++ b/spec/spec_helper/command.rb
@@ -5,7 +5,7 @@ module SpecHelper
     end
 
     def command(*argv)
-      argv << '--no-ansi'
+      argv += ['--no-ansi', '--no-pager']
       Pod::Command.parse(argv)
     end
 


### PR DESCRIPTION
Closes #17.

I need review on this. Solution felt a little bit hackie but I couldn't find a better way to add pager functionality only for search command without affecting other components.

It now looks for `use_pager` attribute (true by default) in order print to a pager or not. If true, It extends `UI` module's functionality by adding a new `puts` method which redirects to correct IO object according to needs.
