### PR TITLE
Removes the dot in the summary, to bring it in line with the rest of CP

### DIFF
--- a/lib/cocoapods-search/command/search.rb
+++ b/lib/cocoapods-search/command/search.rb
@@ -1,7 +1,7 @@
 module Pod
   class Command
     class Search < Command
-      self.summary = 'Search for pods.'
+      self.summary = 'Search for pods'
 
       self.description = <<-DESC
         Searches for pods, ignoring case, whose name, summary, description, or authors match `QUERY`. If the


### PR DESCRIPTION
See https://github.com/CocoaPods/cocoapods-deintegrate/pull/19 
