### PR TITLE
[Docs] CocoaPods Availability

### DIFF
--- a/lib/cocoapods-search/command/search.rb
+++ b/lib/cocoapods-search/command/search.rb
@@ -1,5 +1,7 @@
 module Pod
   class Command
+    # @CocoaPods 0.0.2
+    #
     class Search < Command
       self.summary = 'Search for pods'
 


### PR DESCRIPTION
This was a fun one. `pod search` was introduced in the second CocoaPods version `0.0.2`!, but pulled out into a plugin at `0.39.0`.

https://github.com/CocoaPods/guides.cocoapods.org/pull/115
